### PR TITLE
Ft(swagger-documentation): all endpoint swagger documentation completed

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -33,6 +33,17 @@ export const getAllComments = async (req, res) => {
 	res.status(200).json({ status: "success", data: getComment.comments });
 };
 
+export const getSingleComment = async (req, res) => {
+	const { id } = req.params;
+	const comment = await Comment.findById(id);
+	if (!comment)
+		return res
+			.status(204)
+			.json({ status: false, message: "Comment not found" });
+	res
+		.status(201)
+		.json({ status: "success", message: "Comment found", data: comment });
+};
 export const deleteComment = async (req, res) => {
 	const { id } = req.params;
 	const comment = await Comment.findById(id);

--- a/src/routes/comment.route.js
+++ b/src/routes/comment.route.js
@@ -5,6 +5,7 @@ import {
 	saveComment,
 	getAllComments,
 	deleteComment,
+	getSingleComment,
 } from "../controllers/comment.controller";
 
 import { checkAdminAuth, checkAuth } from "../middleware/check-auth";
@@ -13,6 +14,7 @@ const router = express.Router();
 
 router.post("/:id/comment", checkAuth, saveComment);
 router.get("/:id/comment", getAllComments);
-router.delete("/:id", checkAdminAuth, deleteComment);
+router.get("/comment/:id", getSingleComment);
+router.delete("/comment/:id", checkAdminAuth, deleteComment);
 
 export default router;

--- a/swagger.json
+++ b/swagger.json
@@ -297,6 +297,56 @@
 					}
 				}
 			},
+			"put": {
+				"tags": ["Articles"],
+				"summary": "Update Article",
+				"description": "Update article",
+				"operationId": "Update article",
+				"security": [
+					{
+						"Bearer": []
+					}
+				],
+				"produces": ["application/json"],
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"description": "Article Id",
+						"required": true
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"description": "Resource payload",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"slug": {
+									"type": "string"
+								},
+								"author": {
+									"type": "string"
+								},
+								"content": {
+									"type": "string"
+								}
+							},
+							"required": ["name", "email", "subject", "content"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				}
+			},
 			"delete": {
 				"tags": ["Articles"],
 				"summary": "Delete Article",
@@ -313,8 +363,203 @@
 						"name": "id",
 						"in": "path",
 						"type": "string",
-						"description": "Query Id",
+						"description": "Article Id",
 						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				}
+			}
+		},
+		"/api/v1/articles/{id}/comment": {
+			"get": {
+				"tags": ["Comments"],
+				"summary": "Get all comments",
+				"description": "get all comments",
+				"operationId": "get all comments",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"description": "Article Id",
+						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				},
+				"security": [
+					{
+						"Bearer": []
+					}
+				]
+			},
+			"post": {
+				"tags": ["Comments"],
+				"summary": "Post a new comment",
+				"description": "New comment",
+				"operationId": "New comment",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"description": "Article Id",
+						"required": true
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"description": "Resource payload",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"properties": {
+								"content": {
+									"type": "string"
+								}
+							},
+							"required": ["content"]
+						}
+					}
+				],
+				"security": [
+					{
+						"Bearer": []
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				}
+			}
+		},
+		"/api/v1/articles/comment/{id}": {
+			"get": {
+				"tags": ["Comments"],
+				"summary": "Get Single comment",
+				"description": "get single comment",
+				"operationId": "get single comment",
+				"security": [
+					{
+						"Bearer": []
+					}
+				],
+				"produces": ["application/json"],
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"description": "Comment Id",
+						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Article Sent Successfully"
+					}
+				}
+			},
+			"delete": {
+				"tags": ["Comments"],
+				"summary": "Delete comment",
+				"description": "delete comment",
+				"operationId": "delete comment",
+				"security": [
+					{
+						"Bearer": []
+					}
+				],
+				"produces": ["application/json"],
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"type": "string",
+						"description": "Comment Id",
+						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				}
+			}
+		},
+		"/api/v1/subscribers": {
+			"get": {
+				"tags": ["Subscribe to newsletter"],
+				"summary": "Get all subscribers",
+				"description": "get all subscribers",
+				"operationId": "get all subscribers",
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				},
+				"security": [
+					{
+						"Bearer": []
+					}
+				]
+			},
+			"post": {
+				"tags": ["Subscribe to newsletter"],
+				"summary": "Subscribe to our newsletter",
+				"description": "Subscribe to our newsletter",
+				"operationId": "New subscriber",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"description": "Resource payload",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"properties": {
+								"email": {
+									"type": "string"
+								}
+							},
+							"required": ["email"]
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Query Sent Successfully"
+					}
+				}
+			},
+			"delete": {
+				"tags": ["Subscribe to newsletter"],
+				"summary": "Un-Subscribe to our newsletter",
+				"description": "Un-Subscribe to our newsletter",
+				"operationId": "New subscriber",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"description": "Resource payload",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"properties": {
+								"email": {
+									"type": "string"
+								}
+							},
+							"required": ["email"]
+						}
 					}
 				],
 				"responses": {


### PR DESCRIPTION
#### What does this PR do?

- Implements Documentation of API using Swagger UI

#### Description of Task to be completed? 

Document my API Swagger. 
The documentation should be accessible via my application’s URL

#### How should this be manually tested?

- Clone the repo

- checkout to branch ``chore-swagger-documentation``

- Run `yarn install to install modules

- Run `yarn start:dev` to start the development server

**In your Browser** 

- use this url `http://127.0.0.1:5000/api-docs/`  to be able to access the documentation

#### Any background context you want to provide?
N/A
#### What are the relevant Pivotal Tracker/Trello stories?

- [link to Trello Board](https://trello.com/c/9wj9znH4/28-document-endpoints-011)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/46887030/158515148-9b3fc026-d3c9-4170-95c2-489327d52b80.png)

![image](https://user-images.githubusercontent.com/46887030/158515176-6a952e7d-6357-4536-adcb-eb88ccd12f8f.png)


#### Questions:

N/A